### PR TITLE
add ad-hoc code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,16 @@ jobs:
 
       - name: Run Tests
         run: swift test
-
-      - name: Build App and Create DMG
+        
+      - name: Build and Sign
         run: |
           chmod +x install_app.sh
           chmod +x create_dmg.sh
+          # Build app
+          ./install_app.sh
+          # Ad-hoc code sign (avoids "damaged" error on some systems, though Gatekeeper might still complain)
+          codesign --force --deep --sign - Insomnia.app
+          # Create DMG
           ./create_dmg.sh
 
       - name: Create Release

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .build
 .DS_STORE
 /Insomnia.app
+*.dmg


### PR DESCRIPTION
The release workflow now includes ad-hoc code signing for Insomnia.app to prevent 'damaged' errors and clarifies build steps. The .gitignore file was updated to exclude DMG files from version control.