### PR TITLE
fix: replace force-cast with conditional cast in getBatteryLevel()

### DIFF
--- a/insomnia/SleepManager.swift
+++ b/insomnia/SleepManager.swift
@@ -120,7 +120,7 @@ public class SleepManager: ObservableObject {
         let sources = IOPSCopyPowerSourcesList(snapshot).takeRetainedValue() as Array
         
         for ps in sources {
-            let info = IOPSGetPowerSourceDescription(snapshot, ps).takeUnretainedValue() as! [String: Any]
+            guard let info = IOPSGetPowerSourceDescription(snapshot, ps).takeUnretainedValue() as? [String: Any] else { continue }
             if let isPresent = info[kIOPSIsPresentKey] as? Bool, isPresent,
                let capacity = info[kIOPSCurrentCapacityKey] as? Int,
                let max = info[kIOPSMaxCapacityKey] as? Int {


### PR DESCRIPTION
## Summary
- Replaces `as!` force-cast with `guard let … as? … else { continue }` in `SleepManager.getBatteryLevel()` (`SleepManager.swift:123`)
- Prevents a silent background crash if IOKit returns an unexpected type for a power source description entry
- Malformed entries are now skipped rather than crashing the app

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)