### PR TITLE
fix: address issues #6, #8, #10, #12

### DIFF
--- a/Tests/InsomniaTests/SleepManagerTests.swift
+++ b/Tests/InsomniaTests/SleepManagerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import InsomniaCore
 
+@MainActor
 final class SleepManagerTests: XCTestCase {
     var sleepManager: SleepManager!
     

--- a/insomnia/Info.plist
+++ b/insomnia/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
-	<string></string>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/insomnia/InsomniaApp.swift
+++ b/insomnia/InsomniaApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import InsomniaCore
+import UserNotifications
 
 @main
 struct InsomniaApp: App {
@@ -87,8 +88,11 @@ struct InsomniaApp: App {
         let checker = UpdateChecker()
         checker.checkForUpdates()
         _updateChecker = StateObject(wrappedValue: checker)
-        
+
         // Initialize Core
         _sleepManager = StateObject(wrappedValue: SleepManager.shared)
+
+        // Request notification permission for battery safety alerts
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
     }
 }

--- a/insomnia/Intents.swift
+++ b/insomnia/Intents.swift
@@ -9,13 +9,14 @@ struct ToggleInsomniaIntent: AppIntent {
     @Parameter(title: "Turn On", default: true)
     var turnOn: Bool
 
-    @MainActor
     func perform() async throws -> some IntentResult {
-        let manager = SleepManager.shared
-        if turnOn {
-            manager.activate()
-        } else {
-            manager.deactivate()
+        let on = turnOn
+        await MainActor.run {
+            if on {
+                SleepManager.shared.activate()
+            } else {
+                SleepManager.shared.deactivate()
+            }
         }
         return .result()
     }
@@ -29,13 +30,14 @@ struct SetInsomniaTimerIntent: AppIntent {
     @Parameter(title: "Minutes", default: 60)
     var minutes: Int
 
-    @MainActor
     func perform() async throws -> some IntentResult {
-        let manager = SleepManager.shared
-        if minutes > 0 {
-            manager.activate(for: TimeInterval(minutes * 60))
-        } else {
-            manager.deactivate()
+        let mins = minutes
+        await MainActor.run {
+            if mins > 0 {
+                SleepManager.shared.activate(for: TimeInterval(mins * 60))
+            } else {
+                SleepManager.shared.deactivate()
+            }
         }
         return .result()
     }

--- a/insomnia/SleepManager.swift
+++ b/insomnia/SleepManager.swift
@@ -3,12 +3,11 @@ import IOKit
 import IOKit.pwr_mgt
 import IOKit.ps
 import SwiftUI
-import AppKit
-import ServiceManagement
-
 import ServiceManagement
 import Combine
+import UserNotifications
 
+@MainActor
 public class SleepManager: ObservableObject {
     public static let shared = SleepManager()
 
@@ -25,21 +24,20 @@ public class SleepManager: ObservableObject {
     @Published public var allowDisplaySleep: Bool = false {
         didSet {
             if isActive {
-                // Re-activate to switch assertion type
                 activate(for: remainingTime)
             }
         }
     }
-    
+
     private var assertionID: IOPMAssertionID = 0
     private var timer: Timer?
     private var tickCount = 0
     private let reasonForActivity = "Insomnia - Prevent Sleep" as CFString
-    
+
     public init() {
         self.batterySafetyEnabled = UserDefaults.standard.bool(forKey: "batterySafetyEnabled")
     }
-    
+
     public func toggle() {
         if isActive {
             deactivate()
@@ -47,36 +45,36 @@ public class SleepManager: ObservableObject {
             activate()
         }
     }
-    
+
     public func activate(for duration: TimeInterval? = nil) {
-        // If already active, release existing to be safe or just update timer
         if isActive {
             deactivate()
         }
-        
+
         let assertionType = allowDisplaySleep ? kIOPMAssertionTypePreventUserIdleSystemSleep : kIOPMAssertionTypeNoDisplaySleep
-        
+
         let success = IOPMAssertionCreateWithName(
             assertionType as CFString,
             IOPMAssertionLevel(kIOPMAssertionLevelOn),
             reasonForActivity,
             &assertionID
         )
-        
+
         if success == kIOReturnSuccess {
             isActive = true
             remainingTime = duration
-            
-            // start timer unconditionally to handle both custom duration and battery checking
+
             timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-                self?.tick()
+                Task { @MainActor [weak self] in
+                    self?.tick()
+                }
             }
         } else {
             print("Failed to create IOPMAssertion")
             isActive = false
         }
     }
-    
+
     public func deactivate() {
         if isActive {
             IOPMAssertionRelease(assertionID)
@@ -85,11 +83,12 @@ public class SleepManager: ObservableObject {
         timer?.invalidate()
         timer = nil
         remainingTime = nil
+        tickCount = 0
     }
-    
+
     private func tick() {
         tickCount += 1
-        
+
         if let time = remainingTime {
             if time > 0 {
                 remainingTime = time - 1
@@ -98,27 +97,24 @@ public class SleepManager: ObservableObject {
                 return
             }
         }
-        
-        // Every 30 seconds, check battery
+
         if batterySafetyEnabled && tickCount % 30 == 0 {
             checkBattery()
         }
     }
-    
+
     private func checkBattery() {
         guard let level = SleepManager.getBatteryLevel() else { return }
         if level <= 20 {
             deactivate()
-            DispatchQueue.main.async {
-                self.showBatteryAlert()
-            }
+            sendBatteryNotification()
         }
     }
-    
+
     public static func getBatteryLevel() -> Int? {
         let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
         let sources = IOPSCopyPowerSourcesList(snapshot).takeRetainedValue() as Array
-        
+
         for ps in sources {
             guard let info = IOPSGetPowerSourceDescription(snapshot, ps).takeUnretainedValue() as? [String: Any] else { continue }
             if let isPresent = info[kIOPSIsPresentKey] as? Bool, isPresent,
@@ -129,17 +125,15 @@ public class SleepManager: ObservableObject {
         }
         return nil
     }
-    
-    private func showBatteryAlert() {
-        let alert = NSAlert()
-        alert.messageText = "Battery Safety Triggered"
-        alert.informativeText = "Insomnia has deactivated because your battery dropped below 20%."
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "OK")
-        NSApp.activate(ignoringOtherApps: true)
-        alert.runModal()
+
+    private func sendBatteryNotification() {
+        let content = UNMutableNotificationContent()
+        content.title = "Insomnia Deactivated"
+        content.body = "Battery dropped below 20%. Sleep prevention has been disabled."
+        let request = UNNotificationRequest(identifier: "battery-safety", content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request)
     }
-    
+
     public var iconName: String {
         return isActive ? "open" : "closed"
     }
@@ -159,7 +153,7 @@ public class SleepManager: ObservableObject {
             }
         }
     }
-    
+
     public var remainingTimeIdentifier: String? {
         guard let time = remainingTime else { return nil }
         let minutes = Int(time) / 60

--- a/install_app.sh
+++ b/install_app.sh
@@ -48,6 +48,7 @@ if [ -f "insomnia/Info.plist" ]; then
     sed -i '' 's/$(PRODUCT_NAME)/'"${APP_NAME}"'/g' "${CONTENTS_DIR}/Info.plist"
     sed -i '' 's/$(PRODUCT_BUNDLE_IDENTIFIER)/com.karansangha.'"${APP_NAME}"'/g' "${CONTENTS_DIR}/Info.plist"
     sed -i '' 's/$(MACOSX_DEPLOYMENT_TARGET)/13.0/g' "${CONTENTS_DIR}/Info.plist"
+    sed -i '' 's/$(DEVELOPMENT_LANGUAGE)/en/g' "${CONTENTS_DIR}/Info.plist"
 else
     echo "Generating Info.plist..."
     cat > "${CONTENTS_DIR}/Info.plist" <<EOF


### PR DESCRIPTION
## Changes
* Reset `tickCount` to 0 in `deactivate()` so battery check interval restarts correctly on reactivation, fixes #6
* Replaced focus-stealing `NSAlert.runModal()` and deprecated `NSApp.activate(ignoringOtherApps:)` with a `UNUserNotificationCenter` local notification; permission requested in `InsomniaApp.init()` to avoid crashing in test context, fixes #8
* Set `CFBundleIconFile` to `"AppIcon"` in `Info.plist`; added missing `$(DEVELOPMENT_LANGUAGE)` → `en` substitution in `install_app.sh`, fixes #10
* Annotated `SleepManager` `@MainActor`; Timer callback uses `Task { @MainActor in }`, `AppIntent.perform()` uses `await MainActor.run {}`; `SleepManagerTests` marked `@MainActor` to match, fixes #12

## Test plan
- [x] All 5 tests pass (`swift test`)
- [x] Clean build succeeds (`swift build -c release`)
- [x] Battery notification appears as a system notification (not a modal) when battery drops below 20%
- [x] App icon shows correctly in Finder after running `./install_app.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)